### PR TITLE
update prerequisites and preparation; closes #31

### DIFF
--- a/content/index.rst
+++ b/content/index.rst
@@ -31,23 +31,6 @@ Broadly, this covers:
 - **Lesson development, collaboratively**: how to design lessons and
   teaching materials so that they can be open and shared.
 
-.. prereq::
-
-   This course has no strict prerequisites, but
-
-   * It is helpful if you have attended CodeRefinery or Carpentries
-     workshops, which teach in an interactive and hands-on way.
-
-   * We assume you already have competence in the technical tools you
-     want to teach.  Many of our concepts use examples from
-     CodeRefinery lessons, such as version control or other software
-     development tools.
-
-   * While not a prerequisite for this course, version control (git)
-     is necessary to contribute to lessons development the way we show
-     here (but the lesson design concepts are applicable to other
-     styles, too).
-
 
 .. toctree::
    :maxdepth: 1

--- a/content/other-resources.md
+++ b/content/other-resources.md
@@ -1,5 +1,8 @@
 # Other resources
 
+- The future of teaching" (35 min content only, 45 min with Q&A, or 15 min reading).
+  [Watch it on YouTube](https://www.youtube.com/watch?v=S9Jor12Cxdc)
+  or [read it](https://hackmd.io/KRqQirJ_Rn2SHcE-t1iAUg) if you prefer.
 - [The old "CodeRefinery instructor training"
   program](https://coderefinery.github.io/instructor-training/): this is
   replaced by what you are reading now.
@@ -13,3 +16,8 @@
 - [Teaching Tech Together](https://teachtogether.tech/): a book
   about similar topics by someone involved in Carpentries.
 - [Carpentries general organizational documentation](https://docs.carpentries.org/)
+- [How to help someone use a computer, by Phil Agre](https://www.librarian.net/stax/4965/how-to-help-someone-use-a-computer-by-phil-agre/).
+  Summary: Most of our teaching challenge is helping people to overcome bad user
+  interface design.
+- [The Science of Learning](https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf):
+  provides a brief overview of some key evidence-based results in teaching.

--- a/content/preparation.md
+++ b/content/preparation.md
@@ -8,17 +8,12 @@ Don't worry if you don't have time to do everything here.  The most
 important ones are listed first.
 
 
-
 ## Read "How to help someone use a computer" (5 min)
 
 [How to help someone use a computer, by Phil
-Agre](https://www.librarian.net/stax/4965/how-to-help-someone-use-a-computer-by-phil-agre/)
-
-Summary:
-
-* Most of our teaching challenge is helping people to overcome bad
-  user interface design.
-
+Agre](https://www.librarian.net/stax/4965/how-to-help-someone-use-a-computer-by-phil-agre/).
+Summary: Most of our teaching challenge is helping people to overcome bad user
+interface design.
 
 
 ## Browse a CodeRefinery lesson (5 min)
@@ -30,11 +25,6 @@ obviously).  We would recommend
 [git-intro](https://coderefinery.github.io/git-intro/) if you don't
 have a preference.
 
-Summary:
-
-* Lessons are online and in free-flowing text form.
-
-
 
 ## (optional) Watch "The future of teaching" (35 min content only, 45 min with Q&A, or 15 min reading)
 
@@ -42,9 +32,8 @@ The "The Future of Teaching" talk is a summary of many things in this
 course.  You could watch it as a preparation (or if you are reading on
 your own, as a summary).  This is low priority, since we will cover
 most of these things in the course itself.
-
-* [Watch it on YouTube](https://www.youtube.com/watch?v=S9Jor12Cxdc)
-* or [read it](https://hackmd.io/KRqQirJ_Rn2SHcE-t1iAUg) if you prefer.
+[Watch it on YouTube](https://www.youtube.com/watch?v=S9Jor12Cxdc)
+or [read it](https://hackmd.io/KRqQirJ_Rn2SHcE-t1iAUg) if you prefer.
 
 
 ## (optional) Read "The science of learning" (20 min)
@@ -55,6 +44,3 @@ which provides a brief overview of some key evidence-based results in
 teaching. This paper is also used by [The
 Carpentries](https://carpentries.org/) for their Instructor Training
 workshops.
-
-
-

--- a/content/preparation.md
+++ b/content/preparation.md
@@ -9,13 +9,6 @@ important ones are listed first.
 
 
 
-## Pre-workshop survey (5 min)
-
-Complete our pre-workshop survey (if you have been sent one). Your
-responses will help us to customize the workshop appropriately.
-
-
-
 ## Read "How to help someone use a computer" (5 min)
 
 [How to help someone use a computer, by Phil


### PR DESCRIPTION
- prerequisites removed. they were outdated and created unnecessary barrier that is not relevant anymore.
- trimmed the preparation page
- listed resources from preparation page also in "other resources" so that they are found if somebody skips preparation (very likely).